### PR TITLE
Wavefront middleware

### DIFF
--- a/middleware/echo/README.md
+++ b/middleware/echo/README.md
@@ -1,0 +1,128 @@
+# Middleware-echoweb
+## Instrumentation
+
+1. Create `tracer-config.yaml file`
+2. Create `tracer-routesRegistration`
+3. Call  `init` function and initialise tracer with config file path, routes registration file path, choice of `direct` or `proxy` sender in bool,and wavefront sender config.
+4. Copy tracer-config.yaml, tracer-routesRegistration.yaml file to container in Dockerfile
+
+## Example: tracer-config.yaml file:
+```yaml
+cluster* : production
+shard* : 1
+application : devops-insight
+service : devops-insight-api
+source : VMware
+CustomApplicationTags* :
+	staticTags:
+		customApplicationTagKey : customApplicationTagValue
+	jwtClaims**:
+		- username
+rateSampler* : 10
+durationSampler* : 60
+```
+**optional parameter*
+*If no rate sampler is given it is taken as deterministic sampler ie all traces are sent to wavefront*
+
+***Middleware automatically parses jwt token to add the given claims as tags in the span*
+
+## Example: tracer-routesRegistration.yaml
+```yaml
+routesRegistration:
+		/tracingapi/test.GET:
+				routeSpecificTag: route-tag
+				routeSpecifcMetaTags:
+					routeSpecifcMetaTagKey: routeSpecifcMetaTagValue
+```
+**Routes registration format**
+api-path.HTTP_METHOD
+
+
+## init function:
+### Using Direct Sender
+```go
+func init() {
+	configFilePath := "filePath of tracer-config.yaml file"
+	routesRegistrationFilePath := "filePath of tracer-routesRegistration.yaml file"
+	
+	//Initialising Global tracer
+	err := InitTracer(configFilePath,routesRegistrationFilePath ,EchoWeb, true, wavefrontUrl, Key,flushIntervalSeconds)
+
+	if err != nil {
+		/*
+		Handle Error
+		*/
+	}
+}
+```
+
+### Using In-Direct Sender
+```go
+func init() {
+	configFilePath := "filePath of tracer-config.yaml file"
+	routesRegistrationFilePath := "filePath of tracer-routesRegistration.yaml file"
+	
+	//Initialising Global tracer
+	err := InitTracer(configFilePath,routesRegistrationFilePath,EchoWeb,false, proxyHost, "",flushIntervalSeconds)
+
+	if err != nil {
+		/*
+		Handle Error
+		*/
+	}
+}
+```
+## Cross process context propagation
+```go
+headers:= GetTracingHeadersToInject(c)
+```
+*c - echo context*
+
+ `GetTracingHeadersToInject` func returns headers which can be added to the call when making cross service calls. `Context` is propagated using headers which helps in stiching trace 
+
+## Adding dynamic tags to Span
+To add metadata derived during servicing the request
+```go
+AddDynamicTags(c,tags)
+```
+*c - echo context
+tags - key value pairs of strings*
+
+## Contextual Logger
+```go
+logger:= NewWfLogger(c)
+```
+  
+*c - echo context
+Same usage as default go logger instance given by log lib in go. Ex: logger.Println("Logging")
+Logs are automatically injected with trace id, span id, and parent span id.
+Logs are also sent to wavefront for each call*
+
+**All the function exposed by standard Go Logger are exposed by custom logger with same usage**
+
+
+##  Other tracing methods exposed 
+
+### For manual start of span
+
+```go
+serverSpan,parentSpanId,err:= StartTraceSpan(c,operationName,tags)
+```
+  *c - echo context*
+  
+### For injecting headers in default http client request 
+```go
+httpRequest:= InjectTracerHttp(tracer,span,httpReq)
+```
+
+### Returns headers to be injected from span. To be used when manually starting span within the process
+```go
+tags:= GetTracingHeadersToInjectFromSpan(tracer,span)
+```
+  *c - echo context*
+
+
+### Returns headers to be injected from echo context. To be used when using middleware
+```go
+GetTracingHeadersToInjectFromContext(c)
+```

--- a/middleware/echo/README.md
+++ b/middleware/echo/README.md
@@ -7,7 +7,7 @@
 4. Copy tracer-config.yaml, tracer-routesRegistration.yaml file to container in Dockerfile
 
 ## Example: tracer-config.yaml file:
-```yaml
+```
 cluster* : production
 shard* : 1
 application : devops-insight
@@ -27,14 +27,14 @@ durationSampler* : 60
 ***Middleware automatically parses jwt token to add the given claims as tags in the span*
 
 ## Example: tracer-routesRegistration.yaml
-```yaml
+```
 routesRegistration:
 		/tracingapi/test.GET:
 				routeSpecificTag: route-tag
 				routeSpecifcMetaTags:
 					routeSpecifcMetaTagKey: routeSpecifcMetaTagValue
 ```
-**Routes registration format**
+**Routes registration format:**
 api-path.HTTP_METHOD
 
 

--- a/middleware/echo/wavefront-general-utils.go
+++ b/middleware/echo/wavefront-general-utils.go
@@ -38,3 +38,13 @@ func getClaimsFromJwtToken(jwtToken string) (map[string]interface{}, error) {
 	}
 	return claims, nil
 }
+
+// readFromFile reads data from given file and returns content as string
+func readFromFile(filePath string) (string, error) {
+	dataBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	dataString := string(dataBytes[:])
+	return dataString, nil
+}

--- a/middleware/echo/wavefront-general-utils.go
+++ b/middleware/echo/wavefront-general-utils.go
@@ -1,0 +1,40 @@
+package wavefront
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/labstack/echo"
+)
+
+// parseJwtTokenFromHeadersWithoutValidation fetches JWT token from Authorization
+// header and parses its calims without verifying signature. Use this function
+// only in places where Istio verifies signature
+func parseJwtClaimsFromHeaders(c echo.Context) (map[string]interface{}, error) {
+	// Read headers
+	headers := c.Request().Header
+
+	// Get Authorization header
+	authHeader := headers.Get("Authorization")
+	if len(authHeader) <= 0 {
+		return nil, errors.New("No Authorization header to parse in request")
+	}
+
+	headerSplit := strings.Split(authHeader, " ")
+	jwtToken := headerSplit[1]
+
+	return getClaimsFromJwtToken(jwtToken)
+}
+
+// getClaimsFromJwtToken takes JWT token string and returns claims
+func getClaimsFromJwtToken(jwtToken string) (map[string]interface{}, error) {
+	claims := jwt.MapClaims{}
+	token, _ := jwt.ParseWithClaims(jwtToken, claims, nil) 
+	// nil is for skipping validation
+	// Ignoring above err as we are not validating signature
+	if token == nil {
+		return nil, errors.New("No token while parsing JWT")
+	}
+	return claims, nil
+}

--- a/middleware/echo/wavefront-general-utils.go
+++ b/middleware/echo/wavefront-general-utils.go
@@ -2,6 +2,7 @@ package wavefront
 
 import (
 	"errors"
+	"io/ioutil"
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
@@ -30,7 +31,7 @@ func parseJwtClaimsFromHeaders(c echo.Context) (map[string]interface{}, error) {
 // getClaimsFromJwtToken takes JWT token string and returns claims
 func getClaimsFromJwtToken(jwtToken string) (map[string]interface{}, error) {
 	claims := jwt.MapClaims{}
-	token, _ := jwt.ParseWithClaims(jwtToken, claims, nil) 
+	token, _ := jwt.ParseWithClaims(jwtToken, claims, nil)
 	// nil is for skipping validation
 	// Ignoring above err as we are not validating signature
 	if token == nil {

--- a/middleware/echo/wavefront-sender-utils.go
+++ b/middleware/echo/wavefront-sender-utils.go
@@ -1,0 +1,39 @@
+package wavefront
+
+import (
+	"github.com/wavefronthq/wavefront-sdk-go/senders"
+	wavefront "github.com/wavefronthq/wavefront-sdk-go/senders"
+)
+
+//GetWavefrontDirectSender constructs and returns a direct wavefront sender
+func getWavefrontDirectSender(server string, token string, flushIntervalSeconds int) (wavefront.Sender, error) {
+	var wavefrontSender senders.Sender
+
+	directCfg := &wavefront.DirectConfiguration{
+		Server:               server,
+		Token:                token,
+		BatchSize:            40000,
+		MaxBufferSize:        50000,
+		FlushIntervalSeconds: flushIntervalSeconds,
+	}
+
+	wavefrontSender, err := wavefront.NewDirectSender(directCfg)
+	return wavefrontSender, err
+}
+
+//GetWavefrontProxySender constructs and returns a proxy wavefront sender
+func getWavefrontProxySender(proxyHost string, flushIntervalSeconds int) (wavefront.Sender, error) {
+	var wavefrontSender senders.Sender
+
+	//Creating proxy sender
+	proxyCfg := &wavefront.ProxyConfiguration{
+		Host:                 proxyHost,
+		MetricsPort:          2878,
+		DistributionPort:     2878,
+		TracingPort:          30000,
+		FlushIntervalSeconds: flushIntervalSeconds,
+	}
+
+	wavefrontSender, err := wavefront.NewProxySender(proxyCfg)
+	return wavefrontSender, err
+}

--- a/middleware/echo/wavefront-tracing-config-utils.go
+++ b/middleware/echo/wavefront-tracing-config-utils.go
@@ -1,7 +1,6 @@
 package wavefront
 
 import (
-	"gitlab.eng.vmware.com/devops-insight/devops-insight-commons/utils/file"
 	"gopkg.in/yaml.v2"
 )
 
@@ -36,7 +35,7 @@ type tracerConfig struct {
 //Populates the GlobalTracerConfig.
 func readConfigFromYaml(configFilePath string) (*tracerConfig, error) {
 	// Open our yamlFile
-	configFile, err := file.ReadFromFile(configFilePath)
+	configFile, err := readFromFile(configFilePath)
 	// if we os.Open returns an error then handle it
 	if err != nil {
 		return nil, err

--- a/middleware/echo/wavefront-tracing-config-utils.go
+++ b/middleware/echo/wavefront-tracing-config-utils.go
@@ -1,0 +1,49 @@
+package wavefront
+
+import (
+	"gitlab.eng.vmware.com/devops-insight/devops-insight-commons/utils/file"
+	"gopkg.in/yaml.v2"
+)
+
+//routeMapValue stores tags corresponding to routeMapKey
+type routeToTagMapValue struct {
+	OperationName string            `yaml:"operationName"`
+	Metatags      map[string]string `yaml:"tags"`
+}
+
+//customTags stores tags corresponding to different types
+type customTags struct {
+	JwtClaims  []string          `yaml:"jwtClaims"`
+	StaticTags map[string]string `yaml:"staticTags"`
+}
+
+// TracerConfig can be used to define config while creating
+// tracer object
+type tracerConfig struct {
+	Cluster               string                        `yaml:"cluster"`
+	Shard                 string                        `yaml:"shard"`
+	Application           string                        `yaml:"application"`
+	Service               string                        `yaml:"service"`
+	Source                string                        `yaml:"source"`
+	CustomApplicationTags customTags                    `yaml:"customApplicationTags"`
+	RateSampler           uint64                        `yaml:"rateSampler"`
+	DurationSampler       int64                         `yaml:"durationSampler"`
+	RouteToTagsMap        map[string]routeToTagMapValue `yaml:"routesRegistration"`
+}
+
+//ReadConfigFromyaml reads the config file
+//Constructs the tracer config from it.
+//Populates the GlobalTracerConfig.
+func readConfigFromYaml(configFilePath string) (*tracerConfig, error) {
+	// Open our yamlFile
+	configFile, err := file.ReadFromFile(configFilePath)
+	// if we os.Open returns an error then handle it
+	if err != nil {
+		return nil, err
+	}
+
+	// we unmarshal our byteArray which contains our
+	// yamlFile's content into 'GlobalTracerConfig'
+	yaml.Unmarshal([]byte(configFile), &globalTracerConfig)
+	return globalTracerConfig, nil
+}

--- a/middleware/echo/wavefront-tracing-logger.go
+++ b/middleware/echo/wavefront-tracing-logger.go
@@ -17,7 +17,7 @@ type WfLogger struct {
 	context echo.Context
 }
 
-type writer struct {
+type Writer struct {
 	io.Writer
 	timeFormat string
 }

--- a/middleware/echo/wavefront-tracing-logger.go
+++ b/middleware/echo/wavefront-tracing-logger.go
@@ -40,8 +40,8 @@ func NewWfLogger(context echo.Context) *WfLogger {
 	return Log
 }
 
-//Println formats using the default formats for its operands and writes to standard output. 
-//Spaces are always added between operands and a newline is appended. 
+//Println formats using the default formats for its operands and writes to standard output.
+//Spaces are always added between operands and a newline is appended.
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Println(v ...interface{}) {
@@ -52,7 +52,7 @@ func (wavefrontLogger *WfLogger) Println(v ...interface{}) {
 }
 
 //Print formats using the default formats for its operands and writes to standard output.
-//Spaces are added between operands when neither is a string. 
+//Spaces are added between operands when neither is a string.
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Print(v ...interface{}) {
@@ -61,7 +61,7 @@ func (wavefrontLogger *WfLogger) Print(v ...interface{}) {
 	wavefrontLogger.logger.Print(v...)
 }
 
-//Printf formats according to a format specifier and writes to standard output. 
+//Printf formats according to a format specifier and writes to standard output.
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Printf(format string, v ...interface{}) {
@@ -137,11 +137,6 @@ func (wavefrontLogger *WfLogger) SetPrefix(prefix string) {
 	wavefrontLogger.logger.SetPrefix(newTracePrefix)
 }
 
-//Writer returns the output destination for the standard logger.
-func (wavefrontLogger *WfLogger) Writer() io.Writer {
-	return wavefrontLogger.logger.Writer()
-}
-
 //SetFlags sets the output flags for the logger.
 func (wavefrontLogger *WfLogger) SetFlags(flag int) {
 	wavefrontLogger.logger.SetFlags(flag)
@@ -152,10 +147,10 @@ func (wavefrontLogger *WfLogger) SetOutput(w io.Writer) {
 	wavefrontLogger.logger.SetOutput(w)
 }
 
-//Output writes the output for a logging event. 
-//The string s contains the text to print after the prefix specified by the flags of the Logger. 
-//A newline is appended if the last character of s is not already a newline. 
-//Calldepth is the count of the number of frames to skip when computing the file name and line number 
+//Output writes the output for a logging event.
+//The string s contains the text to print after the prefix specified by the flags of the Logger.
+//A newline is appended if the last character of s is not already a newline.
+//Calldepth is the count of the number of frames to skip when computing the file name and line number
 //if Llongfile or Lshortfile is set; a value of 1 will print the details for the caller of Output.
 func (wavefrontLogger *WfLogger) Output(calldepth int, s string) error {
 	return wavefrontLogger.logger.Output(calldepth, s)

--- a/middleware/echo/wavefront-tracing-logger.go
+++ b/middleware/echo/wavefront-tracing-logger.go
@@ -1,0 +1,170 @@
+package wavefront
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/labstack/echo"
+	"github.com/opentracing/opentracing-go"
+)
+
+type WfLogger struct {
+	logger  *log.Logger
+	context echo.Context
+}
+
+type writer struct {
+	io.Writer
+	timeFormat string
+}
+
+func (w writer) Write(b []byte) (n int, err error) {
+	return w.Writer.Write(append([]byte(time.Now().Format(w.timeFormat)), b...))
+}
+
+//NewWfLogger returns a new custom logger instance with TraceId and SpanId injected.
+//It exposes the same functions as the standard Golang Logger, with added function of injecting trace info in logs.
+//And sending span logs to wavefront.
+func NewWfLogger(context echo.Context) *WfLogger {
+	logPrefix := context.Get("tracePrefix")
+	Log := &WfLogger{
+		logger:  log.New(&writer{os.Stdout, "2006-01-02 15:04:05 "}, fmt.Sprintf("%v", logPrefix), 0),
+		context: context,
+	}
+
+	return Log
+}
+
+//Println formats using the default formats for its operands and writes to standard output. 
+//Spaces are always added between operands and a newline is appended. 
+//It returns the number of bytes written and any write error encountered.
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Println(v ...interface{}) {
+	logObject := fmt.Sprintln(v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Println(v...)
+
+}
+
+//Print formats using the default formats for its operands and writes to standard output.
+//Spaces are added between operands when neither is a string. 
+//It returns the number of bytes written and any write error encountered.
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Print(v ...interface{}) {
+	logObject := fmt.Sprint(v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Print(v...)
+}
+
+//Printf formats according to a format specifier and writes to standard output. 
+//It returns the number of bytes written and any write error encountered.
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Printf(format string, v ...interface{}) {
+	logObject := fmt.Sprintf(format, v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Printf(format, v...)
+}
+
+//Fatal is equivalent to Println() followed by a call to os.Exit(1).
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Fatalln(v ...interface{}) {
+	logObject := fmt.Sprintln(v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Fatalln(v...)
+
+}
+
+//Fatal is equivalent to Print() followed by a call to os.Exit(1).
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Fatal(v ...interface{}) {
+	logObject := fmt.Sprint(v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Fatal(v...)
+}
+
+//Fatal is equivalent to Printf() followed by a call to os.Exit(1).
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Fatalf(format string, v ...interface{}) {
+	logObject := fmt.Sprintf(format, v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Fatalf(format, v...)
+}
+
+//Panic is equivalent to Println() followed by a call to panic().
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Panicln(v ...interface{}) {
+	logObject := fmt.Sprintln(v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Panicln(v...)
+
+}
+
+//Panic is equivalent to Print() followed by a call to panic().
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Panic(v ...interface{}) {
+	logObject := fmt.Sprint(v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Panic(v...)
+}
+
+//Panic is equivalent to Printf() followed by a call to panic().
+//Sends the log object to wavefront.
+func (wavefrontLogger *WfLogger) Panicf(format string, v ...interface{}) {
+	logObject := fmt.Sprintf(format, v...)
+	sendSpanLog(wavefrontLogger.context, logObject)
+	wavefrontLogger.logger.Panicf(format, v...)
+}
+
+//Flags returns the output flags for the  logger.
+func (wavefrontLogger *WfLogger) Flags() int {
+	return wavefrontLogger.logger.Flags()
+}
+
+//Prefix returns the output prefix for the logger.
+func (wavefrontLogger *WfLogger) Prefix() string {
+	return wavefrontLogger.logger.Prefix()
+}
+
+//SetPrefix sets the output prefix in addition to trace Prefix for the logger.
+func (wavefrontLogger *WfLogger) SetPrefix(prefix string) {
+	tracePrefix := wavefrontLogger.logger.Prefix()
+	newTracePrefix := tracePrefix + prefix
+	wavefrontLogger.logger.SetPrefix(newTracePrefix)
+}
+
+//Writer returns the output destination for the standard logger.
+func (wavefrontLogger *WfLogger) Writer() io.Writer {
+	return wavefrontLogger.logger.Writer()
+}
+
+//SetFlags sets the output flags for the logger.
+func (wavefrontLogger *WfLogger) SetFlags(flag int) {
+	wavefrontLogger.logger.SetFlags(flag)
+}
+
+//SetOutput sets the output destination for the logger.
+func (wavefrontLogger *WfLogger) SetOutput(w io.Writer) {
+	wavefrontLogger.logger.SetOutput(w)
+}
+
+//Output writes the output for a logging event. 
+//The string s contains the text to print after the prefix specified by the flags of the Logger. 
+//A newline is appended if the last character of s is not already a newline. 
+//Calldepth is the count of the number of frames to skip when computing the file name and line number 
+//if Llongfile or Lshortfile is set; a value of 1 will print the details for the caller of Output.
+func (wavefrontLogger *WfLogger) Output(calldepth int, s string) error {
+	return wavefrontLogger.logger.Output(calldepth, s)
+}
+
+func sendSpanLog(context echo.Context, v interface{}) {
+	spanPointerInterface := context.Get("spanPointer")
+	if spanPointerInterface == nil {
+		return
+	}
+
+	spanPointer := spanPointerInterface.(*opentracing.Span)
+	(*spanPointer).LogKV("log", v)
+}

--- a/middleware/echo/wavefront-tracing-logger.go
+++ b/middleware/echo/wavefront-tracing-logger.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+//WfLogger custom logger implementation of Go standard Logger
 type WfLogger struct {
 	logger  *log.Logger
 	context echo.Context
@@ -38,8 +39,8 @@ func NewWfLogger(context echo.Context) *WfLogger {
 	return Log
 }
 
-//Println formats using the default formats for its operands and writes to standard output. 
-//Spaces are always added between operands and a newline is appended. 
+//Println formats using the default formats for its operands and writes to standard output.
+//Spaces are always added between operands and a newline is appended.
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Println(v ...interface{}) {
@@ -50,7 +51,7 @@ func (wavefrontLogger *WfLogger) Println(v ...interface{}) {
 }
 
 //Print formats using the default formats for its operands and writes to standard output.
-//Spaces are added between operands when neither is a string. 
+//Spaces are added between operands when neither is a string.
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Print(v ...interface{}) {
@@ -59,7 +60,7 @@ func (wavefrontLogger *WfLogger) Print(v ...interface{}) {
 	wavefrontLogger.logger.Print(v...)
 }
 
-//Printf formats according to a format specifier and writes to standard output. 
+//Printf formats according to a format specifier and writes to standard output.
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Printf(format string, v ...interface{}) {
@@ -150,10 +151,10 @@ func (wavefrontLogger *WfLogger) SetOutput(w io.Writer) {
 	wavefrontLogger.logger.SetOutput(w)
 }
 
-//Output writes the output for a logging event. 
-//The string s contains the text to print after the prefix specified by the flags of the Logger. 
-//A newline is appended if the last character of s is not already a newline. 
-//Calldepth is the count of the number of frames to skip when computing the file name and line number 
+//Output writes the output for a logging event.
+//The string s contains the text to print after the prefix specified by the flags of the Logger.
+//A newline is appended if the last character of s is not already a newline.
+//Calldepth is the count of the number of frames to skip when computing the file name and line number
 //if Llongfile or Lshortfile is set; a value of 1 will print the details for the caller of Output.
 func (wavefrontLogger *WfLogger) Output(calldepth int, s string) error {
 	return wavefrontLogger.logger.Output(calldepth, s)

--- a/middleware/echo/wavefront-tracing-logger.go
+++ b/middleware/echo/wavefront-tracing-logger.go
@@ -11,7 +11,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-//WfLogger custom logger implementation of Go standard Logger
+//WfLogger custom implementation of Go standard Logger
+//Exposes the same functions as Standard Logger
 type WfLogger struct {
 	logger  *log.Logger
 	context echo.Context
@@ -22,7 +23,7 @@ type Writer struct {
 	timeFormat string
 }
 
-func (w writer) Write(b []byte) (n int, err error) {
+func (w Writer) Write(b []byte) (n int, err error) {
 	return w.Writer.Write(append([]byte(time.Now().Format(w.timeFormat)), b...))
 }
 
@@ -32,15 +33,15 @@ func (w writer) Write(b []byte) (n int, err error) {
 func NewWfLogger(context echo.Context) *WfLogger {
 	logPrefix := context.Get("tracePrefix")
 	Log := &WfLogger{
-		logger:  log.New(&writer{os.Stdout, "2006-01-02 15:04:05 "}, fmt.Sprintf("%v", logPrefix), 0),
+		logger:  log.New(&Writer{os.Stdout, "2006-01-02 15:04:05 "}, fmt.Sprintf("%v", logPrefix), 0),
 		context: context,
 	}
 
 	return Log
 }
 
-//Println formats using the default formats for its operands and writes to standard output.
-//Spaces are always added between operands and a newline is appended.
+//Println formats using the default formats for its operands and writes to standard output. 
+//Spaces are always added between operands and a newline is appended. 
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Println(v ...interface{}) {
@@ -51,7 +52,7 @@ func (wavefrontLogger *WfLogger) Println(v ...interface{}) {
 }
 
 //Print formats using the default formats for its operands and writes to standard output.
-//Spaces are added between operands when neither is a string.
+//Spaces are added between operands when neither is a string. 
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Print(v ...interface{}) {
@@ -60,7 +61,7 @@ func (wavefrontLogger *WfLogger) Print(v ...interface{}) {
 	wavefrontLogger.logger.Print(v...)
 }
 
-//Printf formats according to a format specifier and writes to standard output.
+//Printf formats according to a format specifier and writes to standard output. 
 //It returns the number of bytes written and any write error encountered.
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Printf(format string, v ...interface{}) {
@@ -69,7 +70,7 @@ func (wavefrontLogger *WfLogger) Printf(format string, v ...interface{}) {
 	wavefrontLogger.logger.Printf(format, v...)
 }
 
-//Fatal is equivalent to Println() followed by a call to os.Exit(1).
+//Fatalln is equivalent to Println() followed by a call to os.Exit(1).
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Fatalln(v ...interface{}) {
 	logObject := fmt.Sprintln(v...)
@@ -86,7 +87,7 @@ func (wavefrontLogger *WfLogger) Fatal(v ...interface{}) {
 	wavefrontLogger.logger.Fatal(v...)
 }
 
-//Fatal is equivalent to Printf() followed by a call to os.Exit(1).
+//Fatalf is equivalent to Printf() followed by a call to os.Exit(1).
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Fatalf(format string, v ...interface{}) {
 	logObject := fmt.Sprintf(format, v...)
@@ -94,7 +95,7 @@ func (wavefrontLogger *WfLogger) Fatalf(format string, v ...interface{}) {
 	wavefrontLogger.logger.Fatalf(format, v...)
 }
 
-//Panic is equivalent to Println() followed by a call to panic().
+//Panicln is equivalent to Println() followed by a call to panic().
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Panicln(v ...interface{}) {
 	logObject := fmt.Sprintln(v...)
@@ -111,7 +112,7 @@ func (wavefrontLogger *WfLogger) Panic(v ...interface{}) {
 	wavefrontLogger.logger.Panic(v...)
 }
 
-//Panic is equivalent to Printf() followed by a call to panic().
+//Panicf is equivalent to Printf() followed by a call to panic().
 //Sends the log object to wavefront.
 func (wavefrontLogger *WfLogger) Panicf(format string, v ...interface{}) {
 	logObject := fmt.Sprintf(format, v...)
@@ -151,10 +152,10 @@ func (wavefrontLogger *WfLogger) SetOutput(w io.Writer) {
 	wavefrontLogger.logger.SetOutput(w)
 }
 
-//Output writes the output for a logging event.
-//The string s contains the text to print after the prefix specified by the flags of the Logger.
-//A newline is appended if the last character of s is not already a newline.
-//Calldepth is the count of the number of frames to skip when computing the file name and line number
+//Output writes the output for a logging event. 
+//The string s contains the text to print after the prefix specified by the flags of the Logger. 
+//A newline is appended if the last character of s is not already a newline. 
+//Calldepth is the count of the number of frames to skip when computing the file name and line number 
 //if Llongfile or Lshortfile is set; a value of 1 will print the details for the caller of Output.
 func (wavefrontLogger *WfLogger) Output(calldepth int, s string) error {
 	return wavefrontLogger.logger.Output(calldepth, s)

--- a/middleware/echo/wavefront-tracing-middleware.go
+++ b/middleware/echo/wavefront-tracing-middleware.go
@@ -1,0 +1,127 @@
+package wavefront
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/labstack/echo"
+	"github.com/opentracing/opentracing-go"
+	"github.com/wavefronthq/wavefront-opentracing-sdk-go/tracer"
+)
+
+//AddDynamicTags injects the dyanmic tags to the span
+func AddDynamicTags(context *echo.Context, tags map[string]interface{}) {
+	(*context).Set("dynamicTags", tags)
+}
+
+//middlewareTracing custom echoWeb middleware.
+//Enables tracing for the routes defined in tracer-config.go.
+//Injects respective tags for each route defined in the span of each trace.
+func middlewareTracing(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(context echo.Context) error {
+		//Mapping path and request type to Http request to get corresponding tags
+		if routeToTagMapValue, ok := globalTracerConfig.RouteToTagsMap[context.Path()+"."+context.Request().Method]; ok {
+			span, parentSpanId, err := StartTraceSpan(context, routeToTagMapValue.OperationName, routeToTagMapValue.Metatags)
+			if err != nil {
+				log.Println(err)
+			}
+
+			/*EXTRACTING TRACID AND SPANID FROM SPAN
+			  CREATING THE IDENTIFIER TO INJECT IN CONTEXT*/
+			logPrefix := ""
+			sc, ok := span.Context().(tracer.SpanContext)
+			if ok {
+				//If it is null both parent and child will have same span id. Adding parent.span.id as tag
+				if parentSpanId != "" {
+					logPrefix = "traceId:" + sc.TraceID + " " + "spanId:" + sc.SpanID + " " + "parentId:" + parentSpanId + " "
+					span.SetTag("parentId", parentSpanId)
+				} else {
+					logPrefix = "traceId:" + sc.TraceID + " " + "spanId:" + sc.SpanID + " " + "parentId:" + sc.SpanID + " "
+					span.SetTag("parentId", sc.SpanID)
+				}
+
+				//Span reference in context
+				context.Set("spanPointer", &span)
+			}
+
+			//Injecting the prefix in echo context
+			context.Set("tracePrefix", logPrefix)
+
+			//Injecting propagation headers in context
+			propagationHeaders := GetTracingHeadersToInjectFromSpan(Tracer, span)
+			context.Set("propagationHeaders", propagationHeaders)
+
+			//Executing function after the response is written
+			context.Response().After(func() {
+				populateTagsForTrace(context, &span)
+				//Finishing the span
+				span.Finish()
+			})
+		}
+		return next(context)
+	}
+}
+
+//populateDefaultTagsForTrace extracts the required information from context and adds them as tags to the trace
+func populateTagsForTrace(context echo.Context, span *opentracing.Span) {
+	//Extracting Http info to populate as default tags
+	requestMethod := context.Request().Method
+	requestUrl := context.Request().Host + context.Request().RequestURI
+	requestStatus := context.Response().Status
+	userAgent := context.Request().UserAgent()
+	host := context.Request().Host
+
+	//Populating tags with http info
+	(*span).SetTag("http.url", requestUrl)
+	(*span).SetTag("http.method", requestMethod)
+	(*span).SetTag("http.status_code", requestStatus)
+	(*span).SetTag("http.user_agent", userAgent)
+	(*span).SetTag("http.hostname", host)
+
+	if requestStatus > 399 {
+		(*span).SetTag("error", "true")
+	}
+
+	//Populating dynamically added tags
+	populateDynamicTagsForTrace(context, span)
+
+	//Populating JWT tags
+	if len(globalTracerConfig.CustomApplicationTags.JwtClaims) > 0 {
+		populateJwtTagsByClaims(context, span)
+	}
+}
+
+//populateDynamicTagsForTrace extracts the dynamically added tags from context and adds them as tags to the trace
+func populateDynamicTagsForTrace(context echo.Context, span *opentracing.Span) {
+	//Extracing the tags from echo context
+	dynamicTags := context.Get("dynamicTags")
+	tags, ok := dynamicTags.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	//Populating the tags
+	for key, value := range tags {
+		(*span).SetTag(key, value)
+	}
+}
+
+//populateJwtTagsByClaims
+func populateJwtTagsByClaims(context echo.Context, span *opentracing.Span) {
+	jwtClaimsFields := globalTracerConfig.CustomApplicationTags.JwtClaims
+
+	// Fetch all claims from JWT
+	claims, err := parseJwtClaimsFromHeaders(context)
+	if err != nil {
+		return
+	}
+
+	// Fetch claim value. Throw error if username
+	// claim is not present
+	for _, claim := range jwtClaimsFields {
+		claimValue := fmt.Sprintf("%v", claims[claim])
+		if claimValue != "" {
+			(*span).SetTag("jwt."+claim, claimValue)
+		}
+	}
+}

--- a/middleware/echo/wavefront-tracing-utils.go
+++ b/middleware/echo/wavefront-tracing-utils.go
@@ -1,0 +1,172 @@
+package wavefront
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	reporter "github.com/wavefronthq/wavefront-opentracing-sdk-go/reporter"
+	"github.com/wavefronthq/wavefront-opentracing-sdk-go/tracer"
+	wfTracer "github.com/wavefronthq/wavefront-opentracing-sdk-go/tracer"
+	wfApplication "github.com/wavefronthq/wavefront-sdk-go/application"
+	"github.com/wavefronthq/wavefront-sdk-go/senders"
+)
+
+var Tracer opentracing.Tracer
+var globalTracerConfig *tracerConfig
+
+// InitTracer initialize tracer object, initialize the GlobalTracer with this newly created,
+// tracer object.
+// Call utils/wavefront.Tracer to access the tracer object
+//For proxy sender send token as empty string
+func InitTracer(configFilePath string, routesRegistrationFilePath string, echoWeb *echo.Echo, sendDirectly bool, server string, token string, flushIntervalSeconds int) error {
+
+	//Constructing globalTracerConfig from config file
+	tracerConfig, err := readConfigFromYaml(configFilePath)
+	if err != nil {
+		return err
+	}
+	//Registering routes
+	tracerConfig, err = readConfigFromYaml(routesRegistrationFilePath)
+	if err != nil {
+		return err
+	}
+
+	var sender senders.Sender
+	if sendDirectly {
+		// Create the direct sender
+		sender, err = getWavefrontDirectSender(server, token, flushIntervalSeconds)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Create the proxy sender
+		sender, err = getWavefrontProxySender(server, flushIntervalSeconds)
+		if err != nil {
+			return err
+		}
+	}
+	appTags := wfApplication.New(tracerConfig.Application, tracerConfig.Service)
+	if tracerConfig != nil {
+		if len(tracerConfig.Cluster) > 0 {
+			appTags.Cluster = tracerConfig.Cluster
+		}
+		if len(tracerConfig.Shard) > 0 {
+			appTags.Shard = tracerConfig.Shard
+		}
+		if tracerConfig.CustomApplicationTags.StaticTags != nil && len(tracerConfig.CustomApplicationTags.StaticTags) > 0 {
+			for k, v := range tracerConfig.CustomApplicationTags.StaticTags {
+				appTags.CustomTags[k] = v
+			}
+		}
+	}
+	wfReporter := reporter.New(sender, appTags, reporter.Source(tracerConfig.Source))
+	clReporter := reporter.NewConsoleSpanReporter(tracerConfig.Source)
+	reporter := reporter.NewCompositeSpanReporter(wfReporter, clReporter)
+	var durationSampler tracer.DurationSampler
+	var rateSampler tracer.RateSampler
+
+	//Initialising tracer with RateSampler and DurationSampler if given in conifg
+	//If values for RateSampler and DurationSampler is not given, it initalises standard tracer with default values
+	if tracerConfig.DurationSampler > 0 && tracerConfig.RateSampler > 0 {
+		durationSampler = tracer.DurationSampler{Duration: time.Duration(tracerConfig.DurationSampler) * time.Second}
+		rateSampler = tracer.RateSampler{Rate: tracerConfig.RateSampler}
+
+		Tracer = wfTracer.New(reporter, wfTracer.WithSampler(rateSampler), wfTracer.WithSampler(durationSampler))
+	} else if tracerConfig.RateSampler > 0 {
+		rateSampler = tracer.RateSampler{Rate: tracerConfig.RateSampler}
+
+		Tracer = wfTracer.New(reporter, wfTracer.WithSampler(rateSampler))
+	} else if tracerConfig.DurationSampler > 0 {
+		durationSampler = tracer.DurationSampler{Duration: time.Duration(tracerConfig.DurationSampler) * time.Second}
+
+		Tracer = wfTracer.New(reporter, wfTracer.WithSampler(durationSampler))
+	} else {
+		Tracer = wfTracer.New(reporter)
+	}
+
+	//Instantiating Global Tracer
+	opentracing.InitGlobalTracer(Tracer)
+
+	//Enabling Middleware
+	echoWeb.Use(middlewareTracing)
+	log.Println("Tracer Initialized...")
+	return nil
+}
+
+//StartTraceSpan looks for existing context from the headers of the request.
+//If context is found, it starts a child span to the parent span,
+//Else it starts a root span.
+//Tags are added to the respective spans created.
+//If parent span exists parent span id is returned along with child span otherwise root span and "" is returned
+func StartTraceSpan(c echo.Context, appSpecificOperationName string, tags map[string]string) (opentracing.Span, string, error) {
+	var serverSpan opentracing.Span
+	var parentSpanId string
+	wireContext, err := opentracing.GlobalTracer().Extract(
+		opentracing.HTTPHeaders,
+		opentracing.HTTPHeadersCarrier(c.Request().Header))
+	if err != nil {
+		log.Println(err)
+	}
+
+	//Adding parent span Id if exists
+	sc, ok := wireContext.(tracer.SpanContext)
+	if ok {
+		parentSpanId = sc.SpanID
+	}
+
+	// Create the span referring to the RPC client if available.
+	// If wireContext == nil, a root span will be created.
+	serverSpan = opentracing.StartSpan(
+		appSpecificOperationName,
+		ext.RPCServerOption(wireContext))
+
+	//Populating Tags
+	for key, value := range tags {
+		if value != "" {
+			serverSpan.SetTag(key, value)
+		}
+	}
+
+	return serverSpan, parentSpanId, nil
+}
+
+//InjectTracerHttp injects the current span into the tracer.
+//Adds the context of the current span to the headers of the Http request
+//to the previous span of the tracer.
+func InjectTracerHttp(tracer opentracing.Tracer, serverSpan opentracing.Span, httpReq *http.Request) *http.Request {
+	tracer.Inject(
+		serverSpan.Context(),
+		opentracing.HTTPHeaders,
+		opentracing.HTTPHeadersCarrier(httpReq.Header))
+	return httpReq
+}
+
+//GetTracingHeadersToInjectFromSpan returns the headers
+//which Should be added to the request to inject from
+//the current span.
+//To be used when manually starting span inside process
+func GetTracingHeadersToInjectFromSpan(tracer opentracing.Tracer, serverSpan opentracing.Span) map[string]string {
+	httpReq, _ := http.NewRequest("GET", "serviceUrl", nil)
+	tracer.Inject(
+		serverSpan.Context(),
+		opentracing.HTTPHeaders,
+		opentracing.HTTPHeadersCarrier(httpReq.Header))
+	headersToBeInjected := make(map[string]string)
+	for key, value := range httpReq.Header {
+		headersToBeInjected[key] = value[0]
+	}
+	return headersToBeInjected
+}
+
+//GetTracingHeadersToInjectFromContext returns the headers
+//which Should be added to the request to inject from
+//the echo context
+//To be used when using middleware
+func GetTracingHeadersToInjectFromContext(context echo.Context) map[string]string {
+	headersToBeInjected := context.Get("propagationHeaders").(map[string]string)
+	return headersToBeInjected
+}


### PR DESCRIPTION
-Opentracing wrapper which implements a middleware on top of current wavefront-golang-opentracing-sdk. It makes adding wavefront tracing to any golang project very easy with minimum code injection. 
-Custom logger to inject trace info including, traceID, spanID, parentID in logs.
-Span logs are also sent to wavefront.