### PR TITLE
Allow to force sample when debug=true, Report delta counters instead …

### DIFF
--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -259,7 +259,7 @@ func (t *reporter) reportDerivedMetrics(span tracer.RawSpan) {
 	err, _ := getAppTag(string(ext.Error), "false", span.Tags)
 	isError := err == "true"
 	// add http status if span has error
-	if value, found := getAppTag(string(ext.HTTPStatusCode), "", span.Tags); found && isError {
+	if value, found := getAppTag(string(ext.HTTPStatusCode), "", span.Tags); found {
 		tags[string(ext.HTTPStatusCode)] = value
 	}
 	// propagate span kind tag by default

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -269,14 +269,13 @@ func (t *reporter) reportDerivedMetrics(span tracer.RawSpan) {
 	// add operation tag after setting heartbeat tag
 	tags["operationName"] = span.Operation
 
-	errors := t.getCounter(metricName+".error", tags)
+	errors := t.getCounter(reporting.DeltaCounterName(metricName+".error"), tags)
 	if isError {
 		errors.Inc(1)
 	}
-	// remove http error status before sending request and duration metrics
-	delete(tags, string(ext.HTTPStatusCode))
-	t.getCounter(metricName+".total_time.millis", tags).Inc(span.Duration.Nanoseconds() / 1000000)
-	t.getCounter(metricName+".invocation", tags).Inc(1)
+
+	t.getCounter(reporting.DeltaCounterName(metricName+".total_time.millis"), tags).Inc(span.Duration.Nanoseconds() / 1000000)
+	t.getCounter(reporting.DeltaCounterName(metricName+".invocation"), tags).Inc(1)
 	if isError {
 		tagsError := t.copyTags(tags)
 		tagsError["error"] = "true"

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -162,6 +162,11 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	}
 
 	if !s.raw.Context.IsSampled() || !*s.raw.Context.Sampled {
+		debugSpan := s.raw.Tags["debug"] == true
+		s.raw.Context.Sampled = &debugSpan
+	}
+
+	if !s.raw.Context.IsSampled() || !*s.raw.Context.Sampled {
 		errd := s.raw.Tags["error"] == true
 		s.raw.Context.Sampled = &errd
 	}

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
+	"strings"
 )
 
 // Implements the `Span` interface. Created via tracerImpl (see `wavefront.New()`).
@@ -162,12 +163,22 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	}
 
 	if !s.raw.Context.IsSampled() || !*s.raw.Context.Sampled {
-		debugSpan := s.raw.Tags["debug"] == true
+		var debugSpan bool
+		if str, ok := s.raw.Tags["debug"].(string); ok {
+			debugSpan = strings.EqualFold(str, "true")
+		} else {
+			debugSpan = s.raw.Tags["debug"] == true
+		}
 		s.raw.Context.Sampled = &debugSpan
 	}
 
 	if !s.raw.Context.IsSampled() || !*s.raw.Context.Sampled {
-		errd := s.raw.Tags["error"] == true
+		var errd bool
+		if str, ok := s.raw.Tags["error"].(string); ok {
+			errd = strings.EqualFold(str, "true")
+		} else {
+			errd = s.raw.Tags["error"] == true
+		}
 		s.raw.Context.Sampled = &errd
 	}
 	s.tracer.reporter.ReportSpan(s.raw)

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -207,6 +207,17 @@ func TestSamplingError(t *testing.T) {
 	assert.Equal(t, 1, len(reporter.getSampledSpans()), "error tag should turn on sampling")
 }
 
+func TestSamplingDebug(t *testing.T) {
+	reporter := NewInMemoryReporter()
+	tracer := New(reporter, WithSampler(NeverSample{}))
+
+	reporter.Reset()
+	span := tracer.StartSpan("x")
+	span.SetTag("debug", true);
+	span.Finish()
+	assert.Equal(t, 1, len(reporter.getSampledSpans()), "debug tag should turn on sampling")
+}
+
 func TestEmptySpanTag(t *testing.T) {
 	span := spanImpl{}
 	span.SetTag("key", "")

--- a/tracer/span_test.go
+++ b/tracer/span_test.go
@@ -213,7 +213,7 @@ func TestSamplingDebug(t *testing.T) {
 
 	reporter.Reset()
 	span := tracer.StartSpan("x")
-	span.SetTag("debug", true);
+	span.SetTag("debug", true)
 	span.Finish()
 	assert.Equal(t, 1, len(reporter.getSampledSpans()), "debug tag should turn on sampling")
 }


### PR DESCRIPTION
…of counters for generated metrics, Allow http.status to be reported as point tags for all generated metrics.

Fixed #39  and #38 along with support debug=true forced sampling.