### PR TITLE
Fix Jaeger sampling and baggage loss.

### DIFF
--- a/tracer/jaeger_test.go
+++ b/tracer/jaeger_test.go
@@ -1,25 +1,32 @@
 package tracer
 
 import (
-	"github.com/opentracing/opentracing-go"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJaegerWavefrontPropagator_Extract(t *testing.T) {
 	traceIdHeader, baggagePrefix := "uber-trace-id", "uberctx-"
 	tracer := New(NewInMemoryReporter(), WithJaegerPropagator(traceIdHeader, baggagePrefix))
 
-	val := "3871de7e09c53ae8:7499dd16d98ab60e:3771de7e09c55ae8:1"
 	carrier := opentracing.HTTPHeadersCarrier(http.Header{})
-	carrier[traceIdHeader] = []string{val}
+	carrier.Set(traceIdHeader, "3871de7e09c53ae8:7499dd16d98ab60e:3771de7e09c55ae8:1")
+	carrier.Set(baggagePrefix+"key-1", "val-1")
+	carrier.Set(baggagePrefix+"key-2", "val-2")
+
 	ctx, _ := tracer.Extract(JaegerWavefrontPropagator{}, carrier)
-	assert.NotNil(t, ctx)
+	require.IsType(t, SpanContext{}, ctx)
 	assert.Equal(t, "00000000-0000-0000-3871-de7e09c53ae8", ctx.(SpanContext).TraceID)
 	assert.Equal(t, "00000000-0000-0000-7499-dd16d98ab60e", ctx.(SpanContext).SpanID)
 	assert.Equal(t, "00000000-0000-0000-7499-dd16d98ab60e", ctx.(SpanContext).Baggage["parent-id"])
 	assert.True(t, ctx.(SpanContext).IsSampled())
+	assert.True(t, *ctx.(SpanContext).SamplingDecision())
+	assert.Equal(t, "val-1", ctx.(SpanContext).Baggage["Key-1"])
+	assert.Equal(t, "val-2", ctx.(SpanContext).Baggage["Key-2"])
 
 	invalidVal := ":7499dd16d98ab60e:3771de7e09c55ae8:1"
 	invalidCarrier := opentracing.HTTPHeadersCarrier(http.Header{})
@@ -32,10 +39,11 @@ func TestJaegerWavefrontPropagator_Inject(t *testing.T) {
 	traceIdHeader, baggagePrefix := "Uber-Trace-Id", "Uberctx-"
 	tmc := opentracing.HTTPHeadersCarrier(http.Header{})
 	tracer := New(NewInMemoryReporter(), WithJaegerPropagator(traceIdHeader, baggagePrefix))
+	sampled := false
 	spanContext := SpanContext{
 		TraceID: "3871de7e09c53ae8",
 		SpanID:  "7499dd16d98ab60e",
-		Sampled: nil,
+		Sampled: &sampled,
 		Baggage: nil,
 	}
 	spanContext = spanContext.WithBaggageItem("x", "y")
@@ -45,6 +53,7 @@ func TestJaegerWavefrontPropagator_Inject(t *testing.T) {
 	_, ok := tmc[traceIdHeader]
 	assert.True(t, ok)
 	assert.Equal(t, "3871de7e09c53ae8:7499dd16d98ab60e::0", tmc[traceIdHeader][0])
+	assert.Equal(t, "false", tmc["Sampling-Decision"][0])
 }
 
 func TestToUUID(t *testing.T) {


### PR DESCRIPTION
- When the sampling is injected/exported the actual value of the sampling flag was not taken into account.
- On extract the baggage items were lost once because the trace header could come after an item and second the new span context was not assigned to the variable returned.
