### PR TITLE
Add CI check for go mod tidy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ notifications:
 
 # script always run to completion (set +e).
 script:
-  - go get -t -v ./...
+  - go mod tidy -v && git diff --exit-code go.mod go.sum
   - diff -u <(echo -n) <(gofmt -d $(find . -path ./vendor -prune -o -name '*.go' -print)) # exlude vendor dir
   - go test -v -race ./...                   # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer


### PR DESCRIPTION
This ensures we have a clean `go.mod` and `go.sum` before merging PRs.