### PR TITLE
Permit setting a custom ID generator

### DIFF
--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -58,6 +58,13 @@ func WithSampler(sampler Sampler) Option {
 	}
 }
 
+// WithGenerator configures Tracer to use a custom trace id generator implementation.
+func WithGenerator(generator Generator) Option {
+	return func(t *WavefrontTracer) {
+		t.generator = generator
+	}
+}
+
 // WithJaegerPropagator configures Tracer to use Jaeger trace context propagation.
 func WithJaegerPropagator(traceId, baggagePrefix string) Option {
 	return func(args *WavefrontTracer) {
@@ -74,15 +81,13 @@ func WithJaegerPropagator(traceId, baggagePrefix string) Option {
 
 // WithW3CGenerator configures Tracer to generate Trace and Span IDs according to W3C spec.
 func WithW3CGenerator() Option {
-	return func(t *WavefrontTracer) {
-		t.generator = NewGeneratorW3C()
-	}
+	return WithGenerator(NewGeneratorW3C())
 }
 
 // WithW3CPropagator configures Tracer to use trace context propagation according to W3C spec.
 func WithW3CPropagator() Option {
 	return func(t *WavefrontTracer) {
-		// implies W3C Generator
+		// implies W3C Generator. Custom ID generators should use WithGenerator after this option.
 		t.generator = NewGeneratorW3C()
 		t.textPropagator = NewPropagatorW3C()
 	}


### PR DESCRIPTION
We have a use case where we're having the Trace ID serve dual purpose:
First, for tracing; secondly, to maintain an audit log of data change events.
To support the second use case, we'd like to generate our own ID's
in accordance to the KSUID standard published by Segment.io, so that our
ID's are time-sortable. Rather than pull the library in here, I instead
propose a configuration option on the Tracer that would allow us to override
the Generator with one of our own.